### PR TITLE
Ignore non-zebra entries in balance command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "taxi_zebra"
 version = "5.0.0"
 description = "Zebra backend for Taxi"
 readme = "README.rst"
-license = "WTFPL"
+license = {text = "WTFPL"}
 authors = [{ name = "Zebra squad", email = "zebra-squad@liip.ch" }]
 requires-python = ">=3.10"
 dependencies = [

--- a/taxi_zebra/commands.py
+++ b/taxi_zebra/commands.py
@@ -2,6 +2,7 @@ import datetime
 
 import click
 
+from taxi.aliases import aliases_database
 from taxi.commands.base import cli, get_timesheet_collection_for_context
 from taxi.plugins import plugins_registry
 
@@ -50,6 +51,25 @@ def get_last_dow(date):
     return date + datetime.timedelta(days=(6 - date.weekday()))
 
 
+def get_registered_backend_name(backend):
+    for backend_name, registered_backend in plugins_registry._backends_registry.items():
+        if registered_backend is backend:
+            return backend_name
+
+    raise click.ClickException("Could not determine the configured name for the selected Zebra backend.")
+
+
+def get_hours_to_be_pushed(timesheet_collection, backend_name):
+    filtered_entries = timesheet_collection.entries.filter(pushed=False, ignored=False, unmapped=False)
+
+    return sum(
+        entry.hours
+        for entries in filtered_entries.values()
+        for entry in entries
+        if entry.alias in aliases_database and aliases_database[entry.alias].backend == backend_name
+    )
+
+
 @zebra.command()
 @click.pass_context
 def balance(ctx):
@@ -59,9 +79,10 @@ def balance(ctx):
     Like the hours balance, vacation left, etc.
     """
     backend = plugins_registry.get_backends_by_class(ZebraBackend)[0]
+    backend_name = get_registered_backend_name(backend)
 
     timesheet_collection = get_timesheet_collection_for_context(ctx, None)
-    hours_to_be_pushed = timesheet_collection.get_hours(pushed=False, ignored=False, unmapped=False)
+    hours_to_be_pushed = get_hours_to_be_pushed(timesheet_collection, backend_name)
 
     today = datetime.date.today()
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,40 @@
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+import taxi.aliases
+from taxi.aliases import Mapping
+from taxi.plugins import plugins_registry
+from taxi_zebra.commands import get_hours_to_be_pushed, get_registered_backend_name
+
+
+@pytest.fixture
+def aliases_database():
+    taxi.aliases.aliases_database.reset()
+    yield taxi.aliases.aliases_database
+
+
+def test_get_registered_backend_name_returns_configured_backend_name(monkeypatch):
+    backend = object()
+
+    monkeypatch.setattr(plugins_registry, "_backends_registry", {"my_zebra_backend": backend})
+
+    assert get_registered_backend_name(backend) == "my_zebra_backend"
+
+
+def test_get_hours_to_be_pushed_only_counts_entries_for_selected_backend(aliases_database):
+    aliases_database["zebra_alias"] = Mapping(mapping=("1", "1"), backend="my_zebra_backend")
+    aliases_database["other_zebra_alias"] = Mapping(mapping=("2", "2"), backend="other_zebra_backend")
+    aliases_database["local_alias"] = Mapping(mapping=("3", "3"), backend="local")
+
+    filtered_entries = {
+        datetime.date(2026, 4, 1): [
+            SimpleNamespace(alias="zebra_alias", hours=2.5),
+            SimpleNamespace(alias="other_zebra_alias", hours=1.5),
+            SimpleNamespace(alias="local_alias", hours=4),
+        ]
+    }
+    timesheet_collection = SimpleNamespace(entries=SimpleNamespace(filter=lambda **kwargs: filtered_entries))
+
+    assert get_hours_to_be_pushed(timesheet_collection, "my_zebra_backend") == 2.5


### PR DESCRIPTION
## Summary
Filters out aliases pointing to non-zebra activities (e.g., local ones) from the hours balance calculation after push.

## Changes
- Modified `balance` command to only include entries where the alias backend is 'zebra'
- Added filtering logic to exclude local and other non-zebra activities from the balance output

Fixes #6